### PR TITLE
Intelliboard breaks core unittests on postgres

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -88,7 +88,7 @@ class local_intelliboard_observer
                 ROUND((CASE WHEN SUM(g.rawgrademax) > 0 THEN (SUM(g.finalgrade) / SUM(g.rawgrademax)) * 100 ELSE SUM(g.finalgrade) END), 2) as grade
                 FROM {grade_grades} as g
                 INNER JOIN {grade_items} as gi ON gi.id = g.itemid
-                WHERE gi.courseid = ? AND gi.itemtype = \"mod\" AND g.userid = ? AND g.finalgrade IS NOT NULL
+                WHERE gi.courseid = ? AND gi.itemtype = 'mod' AND g.userid = ? AND g.finalgrade IS NOT NULL
                 GROUP BY gi.courseid
         ", [$eventData['courseid'], $eventData['relateduserid']]);
 


### PR DESCRIPTION
The event observers contain SQL queries that are not valid on postgres.
Clearly the unittests for these observers are missing from the local_intelliboard plugin, this is why travis has not detected them.

This pull request fixes the SQL but code coverage in intelliboard plugin's tests needs to be improved.

Fully functioning code on postgres is a requirement for moodlecloud and moodle workplace