### PR TITLE
changes for unique class to resolve conflict with other plugins

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -362,7 +362,7 @@ label.switch {
     height: 0;
 }
 
-.slider {
+.intelliboard-slider {
     position: absolute;
     cursor: pointer;
     top: 0;
@@ -374,7 +374,7 @@ label.switch {
     transition: .4s;
 }
 
-.slider:before {
+.intelliboard-slider:before {
     position: absolute;
     content: "";
     height: 14px;
@@ -387,25 +387,25 @@ label.switch {
     transition: .4s;
 }
 
-input:checked + .slider {
+input:checked + .intelliboard-slider {
     background-color: #2196F3;
 }
 
-input:focus + .slider {
+input:focus + .intelliboard-slider {
     box-shadow: 0 0 1px #2196F3;
 }
 
-input:checked + .slider:before {
+input:checked + .intelliboard-slider:before {
     -webkit-transform: translateX(20px);
     -ms-transform: translateX(20px);
     transform: translateX(20px);
 }
 
-.slider.round {
+.intelliboard-slider.round {
     border-radius: 12px;
 }
 
-.slider.round:before {
+.intelliboard-slider.round:before {
     border-radius: 50%;
 }
 

--- a/templates/setup.mustache
+++ b/templates/setup.mustache
@@ -29,7 +29,7 @@
                         <div class="switch-item">
                             <label class="switch">
                                 <input type="checkbox" name="webservice" value="1" id="webservice" checked="checked">
-                                <span class="slider round"></span>
+                                <span class="intelliboard-slider round"></span>
                             </label>
                             {{#str}}enablews, webservice{{/str}}
                         </div>
@@ -98,7 +98,7 @@
                         <div class="switch-item">
                             <label class="switch">
                                 <input type="checkbox" name="enable_tracking" value="0" id="enable_tracking" checked="checked">
-                                <span class="slider round"></span>
+                                <span class="intelliboard-slider round"></span>
                             </label>
                             {{#str}}enable_time_tracking, local_intelliboard{{/str}}
                             <p class="description">{{#str}}enable_time_tracking_descr, local_intelliboard{{/str}}</p>
@@ -106,7 +106,7 @@
                         <div class="switch-item">
                             <label class="switch">
                                 <input type="checkbox" name="enable_sso_link" value="1" id="enable_sso_link" checked="checked">
-                                <span class="slider round"></span>
+                                <span class="intelliboard-slider round"></span>
                             </label>
                             {{#str}}enable_sso, local_intelliboard{{/str}}
                             <p class="description">{{#str}}enable_sso_descr, local_intelliboard{{/str}}</p>
@@ -147,7 +147,7 @@
                     <div class="switch-item">
                         <label class="switch">
                             <input name="terms" id="termsField" type="checkbox" value="1" required="required">
-                            <span class="slider round"></span>
+                            <span class="intelliboard-slider round"></span>
                         </label>
                         <strong>{{#str}}terms_msg, local_intelliboard{{/str}}</strong>
                     </div>
@@ -159,7 +159,7 @@
                     <div class="switch-item">
                         <label class="switch">
                             <input name="privacy" id="privacyField" type="checkbox" value="1" required="required">
-                            <span class="slider round"></span>
+                            <span class="intelliboard-slider round"></span>
                         </label>
                         <strong>{{#str}}privacy_msg, local_intelliboard{{/str}}</strong>
                     </div>
@@ -171,7 +171,7 @@
                     <div class="switch-item">
                         <label class="switch">
                             <input name="shield" id="shieldField" type="checkbox" value="1" required="required">
-                            <span class="slider round"></span>
+                            <span class="intelliboard-slider round"></span>
                         </label>
                         <strong>{{#str}}shield_msg, local_intelliboard{{/str}}</strong>
                     </div>


### PR DESCRIPTION
Intelliboard plugin has a page setup.php, over there it's using a class called slider.
This class is conflicting with another community plugin block_slider. The conflict is happening from the CSS used for the intelliboard plugin. It's breaking the dashboard with blocks whoever using that block_slider plugin or any other plugin has got any class named as slider. I believe it is always recommended to use class name specific to the plugin.
The changes I made: 
1. Made the change in the setup.mustache from slider to intelliboard-slider.
2. Made changes to the style.css from slider to intelliboard-slider.

