### PR TITLE
Update caches.php

### DIFF
--- a/db/caches.php
+++ b/db/caches.php
@@ -41,6 +41,6 @@ $definitions = [
         'simplekeys' => true,
         'requirelockingwrite' => true,
         'overrideclass' => 'local_intelliboard\tools\cache_application',
-        'overrideclassfile ' => 'local/intelliboard/classes/tools/cache_application.php'
+        'overrideclassfile' => 'local/intelliboard/classes/tools/cache_application.php'
     ]
 ];


### PR DESCRIPTION
Remove extra space in 'overrideclassfile' attribute. This causes the plugin to fail the uninstall process.