### PR TITLE
Issue #53: Fix error check_user_preferences_loaded() must be an instance of stdClass

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -304,9 +304,14 @@ function local_intelliboard_insert_tracking($ajaxRequest = false, $trackparamete
     global $CFG, $PAGE, $SITE, $DB, $USER;
 
     $ajax = (int) get_config('local_intelliboard', 'ajax');
-    $lastajaxtracking = get_user_preferences('last_intelliboard_ajax_tracking', 0);
+    // Validate that at least global $USER is set.
+    $nouserset = true;
+    if (!is_null($USER)) {
+        $nouserset = false;
+        $lastajaxtracking = get_user_preferences('last_intelliboard_ajax_tracking', 0);
+    }
 
-    if ($ajaxRequest && (time() - $lastajaxtracking < $ajax)) {
+    if (($ajaxRequest && (time() - $lastajaxtracking < $ajax)) || $nouserset) {
         return true;
     } else {
         set_user_preference('last_intelliboard_ajax_tracking', time());

--- a/lib.php
+++ b/lib.php
@@ -306,7 +306,7 @@ function local_intelliboard_insert_tracking($ajaxRequest = false, $trackparamete
     $ajax = (int) get_config('local_intelliboard', 'ajax');
     // Validate that at least global $USER is set.
     $nouserset = true;
-    if (!is_null($USER)) {
+    if (isloggedin()) {
         $nouserset = false;
         $lastajaxtracking = get_user_preferences('last_intelliboard_ajax_tracking', 0);
     }


### PR DESCRIPTION
This MR will fix Issue #53 

After Moodle security release, this error is displayed in `/admin/index.php` when purging cache -> Exception - Argument 1 passed to check_user_preferences_loaded() must be an instance of stdClass, null given, called in [dirroot]/lib/moodlelib.php on line 2158

