### PR TITLE
Fix schema alignment and replace deprecated functions

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -908,5 +908,38 @@ function xmldb_local_intelliboard_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022060204, 'local', 'intelliboard');
     }
 
+    if ($oldversion < 2023092500) {
+        $table = new xmldb_table('local_intelliboard_bbb_meet');
+        $field = new xmldb_field('meetingname');
+        $field->set_attributes(XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        try {
+            $dbman->change_field_type($table, $field);
+        } catch (moodle_exception $e) {
+        }
+
+        $field = new xmldb_field('createdate');
+        $field->set_attributes(XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        try {
+            $dbman->change_field_type($table, $field);
+        } catch (moodle_exception $e) {
+        }
+
+        $field = new xmldb_field('dialnumber');
+        $field->set_attributes(XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        try {
+            $dbman->change_field_type($table, $field);
+        } catch (moodle_exception $e) {
+        }
+
+        $field = new xmldb_field('duration');
+        $field->set_attributes(XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        try {
+            $dbman->change_field_type($table, $field);
+        } catch (moodle_exception $e) {
+        }
+
+        upgrade_plugin_savepoint(true, 2023092500, 'local', 'intelliboard');
+    }
+
     return true;
 }

--- a/externallib.php
+++ b/externallib.php
@@ -12825,7 +12825,7 @@ class local_intelliboard_external extends external_api {
             include_once($file);
         }
         if (!class_exists('quiz_statistics_report')) {
-            print_error('preprocesserror', 'quiz');
+            throw new \moodle_exception('preprocesserror', 'quiz');
         }
 
         if (is_array($params->custom)) {
@@ -12959,7 +12959,7 @@ class local_intelliboard_external extends external_api {
             include_once($file);
         }
         if (!class_exists('quiz_statistics_report')) {
-            print_error('preprocesserror', 'quiz');
+            throw new \moodle_exception('preprocesserror', 'quiz');
         }
         if (!empty($params->courseid)) {
             $courses = (is_array($params->courseid)) ? $params->courseid : explode(",", clean_param($params->courseid, PARAM_SEQUENCE));

--- a/student/tables.php
+++ b/student/tables.php
@@ -972,7 +972,7 @@ class intelliboard_used_seats_table extends table_sql {
             'ltype' => \local_intellicart\log::TYPE_USEDSEAT,
             'seatid' => $this->seatid,
         ];
-        $userfields = get_all_user_name_fields(true, 'u');
+        $userfields = \core_user\fields::for_name()->get_sql('u', false, '', '', false)->selects;
         $searchwhere = '';
         if($this->search) {
             $searchwhere = ' AND ('.$DB->sql_like('p.name', ':search1', false, false, false);

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
  * @website    https://intelliboard.net/
  */
 
-$plugin->version = 2023092004;
+$plugin->version = 2023092500;
 $plugin->requires = 2011120500;
 $plugin->release = '7.0.0';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
When upgrading from version 2023062704 to version 2023092004, there were some changes to the table definition in the `local_intelliboard_bbb_meet` table, however, a migration to match the schema was not done/triggered (An old migration was modified but only works for new installs) so I created the migration to align the schema in the last version

Also, I made a tiny change to replace a deprecated function being used