### PR TITLE
Fix implicit conversions and check null values

### DIFF
--- a/classes/output/tables/intelliboard_table.php
+++ b/classes/output/tables/intelliboard_table.php
@@ -73,7 +73,7 @@ abstract class intelliboard_table extends \table_sql {
 
         $delimeter = ':';
 
-        return sprintf("%02d%s%02d%s%02d", floor($row->$columnname/3600), $delimeter, ($row->$columnname/60)%60, $delimeter, $row->$columnname%60);
+        return sprintf("%02d%s%02d%s%02d", floor((int)$row->$columnname/3600), $delimeter, (int)($row->$columnname/60)%60, $delimeter, $row->$columnname%60);
     }
 
     public function icol_int($row, $columnname) {

--- a/student/index.php
+++ b/student/index.php
@@ -363,7 +363,7 @@ echo $OUTPUT->header();
                                                     <?php if($scale_real):?>
                                                         <?php echo $item->grade; ?>
                                                     <?php else:?>
-                                                        <div class="circle-progress d-inline-block"  data-percent="<?php echo round($item->grade, $scale_percentage_round); ?>"></div>
+                                                        <div class="circle-progress d-inline-block"  data-percent="<?php echo round($item->grade ?? 0, $scale_percentage_round); ?>"></div>
                                                     <?php endif;?>
                                                 </td>
                                             <?php endif; ?>
@@ -423,7 +423,7 @@ echo $OUTPUT->header();
                                                     <?php if($scale_real):?>
                                                         <?php echo $item->grade; ?>
                                                     <?php else:?>
-                                                        <div class="circle-progress"  data-percent="<?php echo round($item->grade, $scale_percentage_round); ?>"></div>
+                                                        <div class="circle-progress"  data-percent="<?php echo round($item->grade ?? 0, $scale_percentage_round); ?>"></div>
                                                     <?php endif;?>
                                                 </td>
                                             <?php endif; ?>
@@ -540,7 +540,7 @@ echo $OUTPUT->header();
                                                 <?php if($scale_real):?>
                                                     <?php echo $item->grade; ?>
                                                 <?php else:?>
-                                                    <div class="circle-progress d-inline-block"  data-percent="<?php echo round($item->grade,$scale_percentage_round); ?>"></div>
+                                                    <div class="circle-progress d-inline-block"  data-percent="<?php echo round($item->grade ?? 0,$scale_percentage_round); ?>"></div>
                                                 <?php endif;?>
                                             </td>
                                         <?php endif; ?>
@@ -568,7 +568,7 @@ echo $OUTPUT->header();
                                             <?php if($scale_real):?>
                                                 <?php echo $item->grade; ?>
                                             <?php else:?>
-                                                <div class="circle-progress"  data-percent="<?php echo round($item->grade,$scale_percentage_round); ?>"></div>
+                                                <div class="circle-progress"  data-percent="<?php echo round($item->grade ?? 0,$scale_percentage_round); ?>"></div>
                                             <?php endif;?>
                                         </td>
                                     <?php endif; ?>


### PR DESCRIPTION
Hi, thanks again for the great work on this plugin

In the latest versions, when using PHP 8.1 there are some deprecations regarding implicit conversions and null arguments on the round() function

The warning/errors break the generation of reports, especially in PDF format