### PR TITLE
alteration of function to inject secondary nav link

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -223,6 +223,7 @@ function local_intelliboard_extend_navigation(global_navigation $nav)
         $customMenu->setupMenu();
 	} catch (Exception $e) {}
 }
+
 function local_intelliboard_extend_settings_navigation(settings_navigation $settingsnav, context $context)
 {
     global $CFG;
@@ -244,9 +245,9 @@ function local_intelliboard_extend_settings_navigation(settings_navigation $sett
             }
         }
 
-        $cat = $coursenode->add(get_string('intelliboard_reports', 'local_intelliboard'), null, navigation_node::TYPE_CONTAINER, null, 'intelliboard');
-
-        if (is_array($reports)) {
+        // Only add container if there are reports
+        if (is_array($reports) && !empty($reports)) {
+            $cat = $coursenode->add(get_string('intelliboard_reports', 'local_intelliboard'), null, navigation_node::TYPE_CONTAINER, null, 'intelliboard');
             foreach ($reports as $key=>$report) {
                 $cat->add(format_string($report->name), new moodle_url('/local/intelliboard/instructor/reports.php',array('id'=>format_string($key))), navigation_node::TYPE_CUSTOM);
             }


### PR DESCRIPTION
we noticed that we get an error with the moodle secondary nav where for some reason intelliboard cannot detect reports. I am not sure how to replicate because this was in our non prod environment and for some reason something wasn't working. I altered various things at the au intelliboard end (eg enabling some admin reports, refreshing token etc) and now the link works ok. 

the code attempts to put in a secondary nav link, if various other conditions in config are met, however if there happen to be no reports to present then it produces an error when you click the course reuse link in "more" in secondary nav. 

Anyway, i think this alteration works ok, with a check for reports prior to inserting the link.
